### PR TITLE
[gcloud] Add ssh-key if it doesn't exist.

### DIFF
--- a/rc/provider/gcloud.py
+++ b/rc/provider/gcloud.py
@@ -52,6 +52,14 @@ def _release_ip_address(name, region):
 
 SSH_KEY_PATH = os.path.expanduser('~/.ssh/google_compute_engine')
 
+if not os.path.exists(SSH_KEY_PATH):
+    print("There is no key at {}, creating new key.".format(SSH_KEY_PATH))
+    # Generate new ssh key to log in.
+    # WARNING: It will create a key with an empty passphrase.
+    run(["ssh-keygen", "-f", SSH_KEY_PATH, "-t", "rsa", "-N", '""'])
+    # Upload key
+    run(["gcloud", "compute", "os-login", "ssh-keys", "add", "--key-file={}.pub".format(SSH_KEY_PATH)])
+
 
 def list():
     p = run(['gcloud', 'compute', 'instances', 'list', '--format',


### PR DESCRIPTION
@ailisp It wasn't working locally because I didn't have the key to communicate via ssh without using `gcloud compute ssh`. Add a small fix that automatically creates the key if it doesn't exists and uploads it to the instance. 